### PR TITLE
Updating katex version to fix incorrect rendering of \neq

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,6 +80,6 @@ plugins:
 # Other settings
 # -----------------------------------------------------------------------------
 jquery_version: "1.12.4"
-katex_version: "0.10.0"
+katex_version: "0.10.1"
 anchorjs_version: "3.2.2"
 latexjs_version: "0.11.1"


### PR DESCRIPTION
This \neq is not rendering correctly: slash appears one character space before the = symbol. This issue is present in the notes for lectures 4,9 and 12. The issue is repeatable in another browser.
https://github.com/sailinglab/pgm-spring-2019/blame/master/_posts/2019-01-28-lecture-04.md#L290
https://github.com/sailinglab/pgm-spring-2019/blame/master/_posts/2019-02-13-lecture-09.md#L305
https://github.com/sailinglab/pgm-spring-2019/blame/master/_posts/2019-02-25-lecture-12.md#L319

This is known KaTeX issue https://github.com/KaTeX/KaTeX/issues/1842. 
Updating to KatexVersion "0.10.1" fixes it for me. 